### PR TITLE
Add cryptography package

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -2,3 +2,4 @@ Flask>=3.0.0
 PyMySQL>=1.1.1
 Werkzeug>=3.0.6
 flask-cors>=3.0.10
+cryptography>=42.0.0


### PR DESCRIPTION
Hello,

I am on the TA team for CS498 Spring 2026. I think the backend starter code needs the cryptography package. Otherwise, the backend fails with:

```
HTTP/1.1 500 INTERNAL SERVER ERROR
Server: nginx
Date: Sat, 07 Feb 2026 17:21:00 GMT
Content-Type: application/json
Content-Length: 138
Connection: keep-alive
Access-Control-Allow-Origin: *

{"detail":"'cryptography' package is required for sha256_password or caching_sha2_password auth methods","error":"During event creation"}
```